### PR TITLE
More retries

### DIFF
--- a/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
+++ b/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
@@ -8,7 +8,7 @@
     <Product>Autodesk Forge</Product>
     <Description>Shared code for Forge client sdks</Description>
     <Copyright>Autodesk Inc.</Copyright>
-    <Version>1.0.0-beta1</Version>
+    <Version>1.0.0-beta3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Autodesk.Forge.Core/ForgeHandler.cs
+++ b/src/Autodesk.Forge.Core/ForgeHandler.cs
@@ -93,13 +93,13 @@ namespace Autodesk.Forge.Core
 
             // retry 3 times with exponential backoff and jitter while respecting the RetryAfter header from server
             var retry = errors.WaitAndRetryAsync(
-                retryCount: 3,
+                retryCount: 5,
                 sleepDurationProvider: (retryCount, response, context) =>
                 {
                     // First see how long the server wants us to wait
                     var serverWait = response.Result?.Headers.RetryAfter?.Delta;
                     // Calculate how long we want to wait in milliseconds
-                    var clientWait = (double)rand.Next(500, Math.Min(20000, (int)Math.Pow(2, retryCount) * 500));
+                    var clientWait = (double)rand.Next(500, (int)Math.Pow(2, retryCount) * 1000);
                     var wait = clientWait;
                     if (serverWait.HasValue)
                     {
@@ -110,7 +110,7 @@ namespace Autodesk.Forge.Core
                 onRetryAsync: (response, sleepTime, retryCount, content) => Task.CompletedTask);
 
             // break circuit after 5 errors and keep it broken for 10 seconds
-            var breaker = errors.CircuitBreakerAsync(5, TimeSpan.FromSeconds(10));
+            var breaker = errors.CircuitBreakerAsync(7, TimeSpan.FromSeconds(10));
 
             // timeout after 10 seconds
             var timeout = Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromSeconds(10), Polly.Timeout.TimeoutStrategy.Pessimistic);

--- a/tests/Autodesk.Forge.Core.Test/TestForgeHandler.cs
+++ b/tests/Autodesk.Forge.Core.Test/TestForgeHandler.cs
@@ -282,6 +282,8 @@ namespace Autodesk.Forge.Core.Test
             var sink = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             sink.Protected().As<HttpMessageInvoker>().SetupSequence(o => o.SendAsync(It.Is<HttpRequestMessage>(r => r.RequestUri == req.RequestUri && r.Headers.Authorization.Parameter == cachedToken), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(tooManyRequests)
+                .ReturnsAsync(tooManyRequests)
+                .ReturnsAsync(tooManyRequests)
                 .ThrowsAsync(new HttpRequestException())
                 .ReturnsAsync(gatewayTimeout)
                 .ReturnsAsync(gatewayTimeout);
@@ -302,8 +304,8 @@ namespace Autodesk.Forge.Core.Test
 
             Assert.Equal(System.Net.HttpStatusCode.GatewayTimeout, resp.StatusCode);
 
-            // We retry 3 times so expect 4 calls 
-            sink.Protected().As<HttpMessageInvoker>().Verify(o => o.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(4));
+            // We retry 5 times so expect 6 calls 
+            sink.Protected().As<HttpMessageInvoker>().Verify(o => o.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(6));
             
             sink.VerifyAll();
         }
@@ -382,7 +384,7 @@ namespace Autodesk.Forge.Core.Test
             await Assert.ThrowsAsync<Polly.CircuitBreaker.BrokenCircuitException<HttpResponseMessage>>(async () => await invoker.SendAsync(req, CancellationToken.None));
 
             // We tolerate 5 failures before we break the circuit
-            sink.Protected().As<HttpMessageInvoker>().Verify(o => o.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(5));
+            sink.Protected().As<HttpMessageInvoker>().Verify(o => o.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(7));
 
             sink.VerifyAll();
         }


### PR DESCRIPTION
We now retry 5 times instead of 3. Both numbers are arbitrary.
I also made the wait between timeouts more reasonable: previously the first retry happened exactly 500ms. We now retry with a random wait between 500-1000ms.

Changed package to 1.0.0-beta3.