### PR TITLE
add proxy client

### DIFF
--- a/src/Autodesk.Forge.Core/ForgeConfiguration.cs
+++ b/src/Autodesk.Forge.Core/ForgeConfiguration.cs
@@ -30,6 +30,9 @@ namespace Autodesk.Forge.Core
         }
         public string ClientId { get; set; }
         public string ClientSecret { get; set; }
+        public string ProxyUrl { get; set; }
+        public string ProxyUser { get; set; }
+        public string ProxyPass { get; set; }
         public Uri AuthenticationAddress { get; set; }
     }
 }

--- a/src/Autodesk.Forge.Core/ForgeHandler.cs
+++ b/src/Autodesk.Forge.Core/ForgeHandler.cs
@@ -44,6 +44,28 @@ namespace Autodesk.Forge.Core
             this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             this.TokenCache = new TokenCache();
             this.resiliencyPolicies = GetResiliencyPolicies();
+            var config = this.configuration.Value;
+
+            var handler = new HttpClientHandler();
+            if (config.ProxyUrl != null)
+            {
+                if (config.ProxyUser != null)
+                {
+
+                    Proxy = new WebProxy(config.ProxyUrl);
+                    Proxy.Credentials = new NetworkCredential(config.ProxyUser, config.ProxyPass);
+                }
+                else
+                {
+                    Proxy = new WebProxy(config.ProxyUrl);
+                }
+
+                handler.Proxy = Proxy;
+                handler.UseProxy = true;
+                
+               
+            }
+            this.InnerHandler = handler;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/Autodesk.Forge.Core/ForgeHandler.cs
+++ b/src/Autodesk.Forge.Core/ForgeHandler.cs
@@ -31,6 +31,7 @@ namespace Autodesk.Forge.Core
 {
     public class ForgeHandler : DelegatingHandler
     {
+        private IWebProxy Proxy;
         private const int ForgeGatewayTimeoutSeconds = 10;
         static SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
 

--- a/src/Autodesk.Forge.Core/LegacySampleConfigurationProvider.cs
+++ b/src/Autodesk.Forge.Core/LegacySampleConfigurationProvider.cs
@@ -51,6 +51,22 @@ namespace Autodesk.Forge.Core
             {
                 this.Data.Add("Forge:ClientSecret", secret);
             }
+            
+            var proxyUrl = Environment.GetEnvironmentVariable("FORGE_PROXY_URL");
+            if (!string.IsNullOrEmpty(id))
+            {
+                this.Data.Add("Forge:ProxyUrl", proxyUrl);
+            }
+            var proxyUser = Environment.GetEnvironmentVariable("FORGE_PROXY_USER");
+            if (!string.IsNullOrEmpty(secret))
+            {
+                this.Data.Add("Forge:ProxyUser", proxyUser);
+            }
+            var proxyPass = Environment.GetEnvironmentVariable("FORGE_PROXY_PASS");
+            if (!string.IsNullOrEmpty(secret))
+            {
+                this.Data.Add("Forge:ProxyPass", proxyPass);
+            }
         }
     }
 }

--- a/src/Autodesk.Forge.Core/LegacySampleConfigurationProvider.cs
+++ b/src/Autodesk.Forge.Core/LegacySampleConfigurationProvider.cs
@@ -53,17 +53,17 @@ namespace Autodesk.Forge.Core
             }
             
             var proxyUrl = Environment.GetEnvironmentVariable("FORGE_PROXY_URL");
-            if (!string.IsNullOrEmpty(id))
+            if (!string.IsNullOrEmpty(proxyUrl))
             {
                 this.Data.Add("Forge:ProxyUrl", proxyUrl);
             }
             var proxyUser = Environment.GetEnvironmentVariable("FORGE_PROXY_USER");
-            if (!string.IsNullOrEmpty(secret))
+            if (!string.IsNullOrEmpty(proxyUser))
             {
                 this.Data.Add("Forge:ProxyUser", proxyUser);
             }
             var proxyPass = Environment.GetEnvironmentVariable("FORGE_PROXY_PASS");
-            if (!string.IsNullOrEmpty(secret))
+            if (!string.IsNullOrEmpty(proxyPass))
             {
                 this.Data.Add("Forge:ProxyPass", proxyPass);
             }


### PR DESCRIPTION
Some Forge DA users would like to the API over their proxy server. 
You can use proxy client when you set the environment variable "FORGE_PROXY_URL".