### PR TITLE
Enable dependabot, so the dependences can be updated partially automated  

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "dotnet:nuget"
+    directory: "/"
+    update_schedule: "monthly"
+    default_reviewers:
+      - "szilvaa"
+      - "augustogoncalves"
+      - "zhuliice"
+    default_labels:
+      - "dependencies"
+      - "dependabot"


### PR DESCRIPTION
don't blame me if it doesn't work since I don't know either 😺  but we should see some PRs created by dependabot for nuget packages upgrade