### PR TITLE
throw TooManyRequestsException for HttpStatusCode.TooManyRequests

### DIFF
--- a/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
+++ b/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
@@ -9,9 +9,9 @@
     <Product>Autodesk Forge</Product>
     <Description>Shared code for Forge client sdks</Description>
     <Copyright>Autodesk Inc.</Copyright>
-    <Version>2.0.0</Version>
-	  <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
+    <Version>2.0.1</Version>
+	  <AssemblyVersion>2.0.1.0</AssemblyVersion>
+    <FileVersion>2.0.1.0</FileVersion>
 	  <PackageId>Autodesk.Forge.Core</PackageId>
 	  <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Autodesk-Forge/forge-api-dotnet-core</PackageProjectUrl>

--- a/src/Autodesk.Forge.Core/ForgeHandler.cs
+++ b/src/Autodesk.Forge.Core/ForgeHandler.cs
@@ -138,7 +138,7 @@ namespace Autodesk.Forge.Core
                 .Or<Polly.Timeout.TimeoutRejectedException>()// thrown by Polly's TimeoutPolicy if the inner call times out
                 .OrResult<HttpResponseMessage>(response =>
                 {
-                    //we want to break the circuit if retriable erros persist or internal errors from the server
+                    //we want to break the circuit if retriable errors persist or internal errors from the server
                     return retriable.Contains((int)response.StatusCode) || 
                            response.StatusCode == HttpStatusCode.InternalServerError;
                 })


### PR DESCRIPTION
There is a request that if the error is 429 (too many requests), Retry-After header is expected to read from the exception. We throw TooManyRequestsException which contains ` Retry-After` information, specifically for `429`