### PR TITLE
Enable to use default forge app via DesignAutomationClientFactory

### DIFF
--- a/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
+++ b/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
@@ -8,9 +8,9 @@
     <Product>Autodesk Forge</Product>
     <Description>Shared code for Forge client sdks</Description>
     <Copyright>Autodesk Inc.</Copyright>
-    <Version>3.0.0</Version>
-	<AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
+    <Version>3.0.1</Version>
+	<AssemblyVersion>3.0.1.0</AssemblyVersion>
+    <FileVersion>3.0.1.0</FileVersion>
 	  <PackageId>Autodesk.Forge.Core</PackageId>
 	  <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Autodesk-Forge/forge-api-dotnet-core</PackageProjectUrl>

--- a/src/Autodesk.Forge.Core/ForgeAgentHandler.cs
+++ b/src/Autodesk.Forge.Core/ForgeAgentHandler.cs
@@ -20,6 +20,8 @@ namespace Autodesk.Forge.Core
 {
     public class ForgeAgentHandler : DelegatingHandler
     {
+        public const string defaultAgentName = "default";
+        
         private string user;
         public ForgeAgentHandler(string user)
         {

--- a/src/Autodesk.Forge.Core/ForgeHandler.cs
+++ b/src/Autodesk.Forge.Core/ForgeHandler.cs
@@ -33,7 +33,7 @@ namespace Autodesk.Forge.Core
 
         protected ITokenCache TokenCache { get; private set; }
 
-        private bool DoesUseDefaultClient(string user) => string.IsNullOrEmpty(user) || user == ForgeAgentHandler.defaultAgentName;
+        private bool IsDefaultClient(string user) => string.IsNullOrEmpty(user) || user == ForgeAgentHandler.defaultAgentName;
 
         public ForgeHandler(IOptions<ForgeConfiguration> configuration)
         {
@@ -181,12 +181,12 @@ namespace Autodesk.Forge.Core
             using (var request = new HttpRequestMessage())
             {
                 var config = this.configuration.Value;
-                var clientId = this.DoesUseDefaultClient(user) ? config.ClientId : config.Agents[user].ClientId;
+                var clientId = this.IsDefaultClient(user) ? config.ClientId : config.Agents[user].ClientId;
                 if (string.IsNullOrEmpty(clientId))
                 {
                     throw new ArgumentNullException($"{nameof(ForgeConfiguration)}.{nameof(ForgeConfiguration.ClientId)}");
                 }
-                var clientSecret = this.DoesUseDefaultClient(user) ? config.ClientSecret : config.Agents[user].ClientSecret;
+                var clientSecret = this.IsDefaultClient(user) ? config.ClientSecret : config.Agents[user].ClientSecret;
                 if (string.IsNullOrEmpty(clientSecret))
                 {
                     throw new ArgumentNullException($"{nameof(ForgeConfiguration)}.{nameof(ForgeConfiguration.ClientSecret)}");

--- a/src/Autodesk.Forge.Core/ForgeHandler.cs
+++ b/src/Autodesk.Forge.Core/ForgeHandler.cs
@@ -28,9 +28,12 @@ namespace Autodesk.Forge.Core
         private static SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
         private readonly Random rand = new Random();
         private readonly IAsyncPolicy<HttpResponseMessage> resiliencyPolicies;
+
         protected readonly IOptions<ForgeConfiguration> configuration;
 
         protected ITokenCache TokenCache { get; private set; }
+
+        private bool DoesUseDefaultClient(string user) => string.IsNullOrEmpty(user) || user == ForgeAgentHandler.defaultAgentName;
 
         public ForgeHandler(IOptions<ForgeConfiguration> configuration)
         {
@@ -178,12 +181,12 @@ namespace Autodesk.Forge.Core
             using (var request = new HttpRequestMessage())
             {
                 var config = this.configuration.Value;
-                var clientId = string.IsNullOrEmpty(user) ? config.ClientId : config.Agents[user].ClientId;
+                var clientId = this.DoesUseDefaultClient(user) ? config.ClientId : config.Agents[user].ClientId;
                 if (string.IsNullOrEmpty(clientId))
                 {
                     throw new ArgumentNullException($"{nameof(ForgeConfiguration)}.{nameof(ForgeConfiguration.ClientId)}");
                 }
-                var clientSecret = string.IsNullOrEmpty(user) ? config.ClientSecret : config.Agents[user].ClientSecret;
+                var clientSecret = this.DoesUseDefaultClient(user) ? config.ClientSecret : config.Agents[user].ClientSecret;
                 if (string.IsNullOrEmpty(clientSecret))
                 {
                     throw new ArgumentNullException($"{nameof(ForgeConfiguration)}.{nameof(ForgeConfiguration.ClientSecret)}");


### PR DESCRIPTION
We can create `DesignAutomationClient` via this [code](https://github.com/Autodesk-Forge/forge-api-dotnet-design.automation/blob/3ad33f4fa59470b633b70b42287d786d831903b7/src/Autodesk.Forge.DesignAutomation/ApiClientFactory.cs#L37) , but `agent = null` won't work because `httpClientFactory.CreateClient(agent)` throws exception for null input. 
Instead, I hope that when I pass  `agent = null` in `DesignAutomationClientFactory.CreateClient`, the default forge app ClientId/ClientSecret will be used then. So we can use default forge app and forge apps in Agents list via DesignAutomationClientFactory easily

The PR for forge-api-dotnet-design.automation: https://github.com/Autodesk-Forge/forge-api-dotnet-design.automation/pull/33