### PR TITLE
Update to dotnet8

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/Autodesk.Forge.sln
+++ b/Autodesk.Forge.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.106
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34928.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autodesk.Forge.Core", "src\Autodesk.Forge.Core\Autodesk.Forge.Core.csproj", "{E59655EF-C1BF-4318-B344-B2C6B67E1A74}"
 EndProject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 4.0.0.0
+
+* Migrate to .Net 8
+
 ### 3.0.0.0
 
 * Migrate to .Net 6

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <TargetFramework>net6.0</TargetFramework>
+   <TargetFramework>net8.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Requirements
 
-- .NET 6 or later
+- .NET 8 or later
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 ### Dependencies
 
-- [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) 13.0.1 or later
-- [Polly](https://github.com/App-vNext/Polly) 7.2.3 or later
+- [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json)
+- [Polly](https://github.com/App-vNext/Polly)
 
 ### Changelog
 

--- a/src/Autodesk.Forge.Core.E2eTestHelpers/Autodesk.Forge.Core.E2eTestHelpers.csproj
+++ b/src/Autodesk.Forge.Core.E2eTestHelpers/Autodesk.Forge.Core.E2eTestHelpers.csproj
@@ -1,36 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>Autodesk Forge Team</Authors>
-    <Company>Autodesk</Company>
-    <Product>Autodesk Forge</Product>
     <Description>Shared code for Forge client sdks e2e tests</Description>
-    <Copyright>Autodesk Inc.</Copyright>
-    <Version>3.0.1</Version>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/Autodesk-Forge/forge-api-dotnet-core</PackageProjectUrl>
-    <PackageIcon>logo_forge-2-line.png</PackageIcon>
-    <PackageReleaseNotes>For full release notes see https://github.com/Autodesk-Forge/forge-api-dotnet-core/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageVersion>4.0.0</PackageVersion>
+    <IsTestProject>false</IsTestProject>
+    <NoWarn>NU5100</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\images\logo_forge-2-line.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit.assert" Version="2.6.4" />
-    <PackageReference Include="xunit.core" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit.assert" Version="2.8.1" />
+    <PackageReference Include="xunit.core" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  <PropertyGroup>
-    <IsTestProject>false</IsTestProject>
-  </PropertyGroup>
 
-  <Import Project="../../nuget.targets" />
 </Project>

--- a/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
+++ b/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
@@ -1,37 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  
   <PropertyGroup>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>Autodesk Forge</Authors>
-	  <owners>Autodesk Forge</owners>
-    <Company>Autodesk</Company>
-    <Product>Autodesk Forge</Product>
-    <Description>Shared code for Forge client sdks</Description>
-    <Copyright>Autodesk Inc.</Copyright>
-    <Version>3.0.2</Version>
-	<AssemblyVersion>3.0.2.0</AssemblyVersion>
-    <FileVersion>3.0.2.0</FileVersion>
-	  <PackageId>Autodesk.Forge.Core</PackageId>
-	  <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/Autodesk-Forge/forge-api-dotnet-core</PackageProjectUrl>
-    <PackageIcon>logo_forge-2-line.png</PackageIcon>
-    <PackageReleaseNotes>For full release notes see https://github.com/Autodesk-Forge/forge-api-dotnet-core/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <Description>Shared code for APS client sdks</Description>
+    <PackageVersion>4.0.0</PackageVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\..\images\logo_forge-2-line.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Polly" Version="8.2.1" />
+    <PackageReference Include="Polly" Version="8.4.0" />
   </ItemGroup>
 
-  <Import Project="../../nuget.targets" />
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+    <PropertyGroup>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <Authors>Autodesk</Authors>
+        <Copyright>Autodesk Inc.</Copyright>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/Autodesk-Forge/forge-api-dotnet-core</PackageProjectUrl>
+        <PackageIcon>logo_forge-2-line.png</PackageIcon>
+        <PackageReleaseNotes>For full release notes see https://github.com/Autodesk-Forge/forge-api-dotnet-core/blob/master/CHANGELOG.md</PackageReleaseNotes>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+    <ItemGroup>
+        <None Include="..\..\images\logo_forge-2-line.png" Pack="true" PackagePath="\" />
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,10 +1,11 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
   <!-- Push the nuget package that this project builds to nuget.org
   Ignore exit code so failures including the value of NugetApiKey do not get echo-ed.
   Continue on errors. Publishing can fail if the package version isn't updated and we get conflict.
   -->
   <Target Name="Push" DependsOnTargets="Pack">
-    <Exec Command="dotnet nuget push @(NuGetPackOutput->WithMetadataValue('Extension','.nupkg')) -k=$(NugetApiKey) -s nuget.org"  
+    <Exec Command="dotnet nuget push @(NuGetPackOutput->WithMetadataValue('Extension','.nupkg')) -k=$(NugetApiKey) -s nuget.org"
           IgnoreExitCode="true"
           ContinueOnError="true"/>
   </Target>

--- a/tests/Autodesk.Forge.Core.Test/Autodesk.Forge.Core.Test.csproj
+++ b/tests/Autodesk.Forge.Core.Test/Autodesk.Forge.Core.Test.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.6.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Autodesk.Forge.Core.Test/TestForgeAgentHandler.cs
+++ b/tests/Autodesk.Forge.Core.Test/TestForgeAgentHandler.cs
@@ -12,7 +12,7 @@ namespace Autodesk.Forge.Core.Test
     public class TestForgeAgentHandler
     {
         [Fact]
-        public async void TestUser()
+        public async Task TestUser()
         {
             var json = @"
             {

--- a/tests/Autodesk.Forge.Core.Test/TestForgeHandler.cs
+++ b/tests/Autodesk.Forge.Core.Test/TestForgeHandler.cs
@@ -37,14 +37,14 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
-        public async void TestNoRequestUriThrows()
+        public async Task TestNoRequestUriThrows()
         {
             var fh = new HttpMessageInvoker(new ForgeHandler(Options.Create(new ForgeConfiguration())));
             await Assert.ThrowsAsync<ArgumentNullException>($"{nameof(HttpRequestMessage)}.{nameof(HttpRequestMessage.RequestUri)}", () => fh.SendAsync(new HttpRequestMessage(), CancellationToken.None));
         }
 
         [Fact]
-        public async void TestNoClientIdThrows()
+        public async Task TestNoClientIdThrows()
         {
             var fh = new HttpMessageInvoker(new ForgeHandler(Options.Create(new ForgeConfiguration())));
             var req = new HttpRequestMessage();
@@ -54,7 +54,7 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
-        public async void TestNoClientSecretThrows()
+        public async Task TestNoClientSecretThrows()
         {
             var fh = new HttpMessageInvoker(new ForgeHandler(Options.Create(new ForgeConfiguration() { ClientId = "ClientId" })));
             var req = new HttpRequestMessage();
@@ -64,7 +64,7 @@ namespace Autodesk.Forge.Core.Test
         }
         
         [Fact]
-        public async void TestFirstCallAuthenticates()
+        public async Task TestFirstCallAuthenticates()
         {
             var sink = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             sink.Protected().As<HttpMessageInvoker>().SetupSequence(o => o.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
@@ -97,7 +97,7 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
-        public async void TestFirstCallAuthenticatesNonDefaultUser()
+        public async Task TestFirstCallAuthenticatesNonDefaultUser()
         {
             var req = new HttpRequestMessage();
             var config = new ForgeConfiguration()
@@ -153,7 +153,7 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
-        public async void TestRetryOnceOnAuthenticationFailure()
+        public async Task TestRetryOnceOnAuthenticationFailure()
         {
             var newToken = "newToken";
             var cachedToken = "cachedToken";
@@ -202,7 +202,7 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
-        public async void TestRefreshExpiredToken()
+        public async Task TestRefreshExpiredToken()
         {
             var newToken = "newToken";
             var cachedToken = "cachedToken";
@@ -245,7 +245,7 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
-        public async void TestRefreshExpiredTokenByOneThreadOnly()
+        public async Task TestRefreshExpiredTokenByOneThreadOnly()
         {
             var newToken = "newToken";
             var cachedToken = "cachedToken";
@@ -300,7 +300,7 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
-        public async void TestUseGoodToken()
+        public async Task TestUseGoodToken()
         {
             var cachedToken = "cachedToken";
             var req = new HttpRequestMessage();
@@ -339,7 +339,7 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
-        public async void TestNoRefreshOnClientProvidedToken()
+        public async Task TestNoRefreshOnClientProvidedToken()
         {
             var token = "blabla";
             var req = new HttpRequestMessage();
@@ -382,7 +382,7 @@ namespace Autodesk.Forge.Core.Test
     public class TestForgeHandler2
     {
         [Fact]
-        public async void TestCorrectNumberOfRetries()
+        public async Task TestCorrectNumberOfRetries()
         {
             var cachedToken = "cachedToken";
             var req = new HttpRequestMessage();
@@ -431,7 +431,7 @@ namespace Autodesk.Forge.Core.Test
     public class TestForgeHandler3
     {
         [Fact]
-        public async void TestTimeout()
+        public async Task TestTimeout()
         {
             var cachedToken = "cachedToken";
             var req = new HttpRequestMessage();
@@ -470,7 +470,7 @@ namespace Autodesk.Forge.Core.Test
     public class TestForgeHandler4
     { 
         [Fact]
-        public async void TestCircuitBreaker()
+        public async Task TestCircuitBreaker()
         {
             var cachedToken = "cachedToken";
             var req = new HttpRequestMessage();
@@ -529,7 +529,7 @@ namespace Autodesk.Forge.Core.Test
                                                             };
 
         [Fact]
-        public async void TestTriggeredTimeout()
+        public async Task TestTriggeredTimeout()
         {
             var (sink, requestSender) = GetReady(1, TimeSpan.FromMilliseconds(1100));
             await Assert.ThrowsAsync<Polly.Timeout.TimeoutRejectedException>(async () => await requestSender());
@@ -538,7 +538,7 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
-        public async void TestNoTimeout()
+        public async Task TestNoTimeout()
         {
             var (sink, requestSender) = GetReady(1, TimeSpan.FromMilliseconds(100));
 

--- a/tests/Autodesk.Forge.Core.Test/TestMarshalling.cs
+++ b/tests/Autodesk.Forge.Core.Test/TestMarshalling.cs
@@ -6,33 +6,33 @@ namespace Autodesk.Forge.Core.Test
     public class TestMarshalling
     {
         [Fact]
-        public async void TestDeserializeThrowsOnNull()
+        public async Task TestDeserializeThrowsOnNull()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(() => Marshalling.DeserializeAsync<string>(null));
         }
 
         [Fact]
-        public async void TestDeserializeNonJsonThrows()
+        public async Task TestDeserializeNonJsonThrows()
         {
             await Assert.ThrowsAsync<ArgumentException>(() => Marshalling.DeserializeAsync<string>(new ByteArrayContent(new byte[] { 0, 2, 3 })));
         }
 
         [Fact]
-        public async void TestDeserializeValidString()
+        public async Task TestDeserializeValidString()
         {
             var ret = await Marshalling.DeserializeAsync<string>(new StringContent("\"bla\"", Encoding.UTF8, "application/json"));
             Assert.Equal("bla", ret);
         }
 
         [Fact]
-        public async void TestDeserializeNull()
+        public async Task TestDeserializeNull()
         {
             var ret = await Marshalling.DeserializeAsync<string>(new StringContent("null", Encoding.UTF8, "application/json"));
             Assert.Null(ret);
         }
 
         [Fact]
-        public async void TestDeserializeNullInvalid()
+        public async Task TestDeserializeNullInvalid()
         {
             await Assert.ThrowsAsync <Newtonsoft.Json.JsonSerializationException>(() => Marshalling.DeserializeAsync<int>(new StringContent("null", Encoding.UTF8, "application/json")));
         }


### PR DESCRIPTION
.NET 6 is going out of support later this year so let's switch over to the latest LTS (.net8).
Also added source link and symbols to the package for easier debugging.