### PR TITLE
Support net6.0 and net8.0

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -23,7 +23,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: | 
+            6.0.x
+            8.0.x
     
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 4.0.2
+
+* Support .Net 8 and .Net 6
+
 ### 4.0.1
 
 * Add Documentation in the `Autodesk.Forge.Core` project.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>4.0.1</Version>
+   <Version>4.0.2</Version>
    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
    <ImplicitUsings>enable</ImplicitUsings>
  </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
  <PropertyGroup>
    <Version>4.0.1</Version>
-   <TargetFramework>net8.0</TargetFramework>
+   <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
    <ImplicitUsings>enable</ImplicitUsings>
  </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![SDK](https://img.shields.io/badge/SDK-3.0.0-lightgree.svg)](https://github.com/Autodesk-Forge/forge-api-dotnet-core)
 [![.NET](https://img.shields.io/badge/.NET%20-6.0-blue.svg)](https://github.com/Autodesk-Forge/forge-api-dotnet-core)
 [![BUILD](https://github.com/Autodesk-Forge/forge-api-dotnet-core/workflows/.NET%20Core/badge.svg?branch=main)](https://github.com/Autodesk-Forge/forge-api-dotnet-core/actions)
-[![Release](https://img.shields.io/nuget/v/Autodesk.Forge.Core?logo=nuget&label=nuget&color=blue)](https://www.nuget.org/packages/Autodesk.Forge.Core)
+[![nuget](https://img.shields.io/nuget/v/Autodesk.Forge.Core?logo=nuget&label=nuget&color=blue)](https://www.nuget.org/packages/Autodesk.Forge.Core)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Autodesk.Forge.Core
 
-![SDK](https://img.shields.io/badge/SDK-3.0.0-lightgree.svg)
-![.NET](https://img.shields.io/badge/.NET%20-6.0-blue.svg)
-![BUILD](https://github.com/Autodesk-Forge/forge-api-dotnet-core/workflows/.NET%20Core/badge.svg?branch=main)
+[![SDK](https://img.shields.io/badge/SDK-3.0.0-lightgree.svg)](https://github.com/Autodesk-Forge/forge-api-dotnet-core)
+[![.NET](https://img.shields.io/badge/.NET%20-6.0-blue.svg)](https://github.com/Autodesk-Forge/forge-api-dotnet-core)
+[![BUILD](https://github.com/Autodesk-Forge/forge-api-dotnet-core/workflows/.NET%20Core/badge.svg?branch=main)](https://github.com/Autodesk-Forge/forge-api-dotnet-core/actions)
+[![Release](https://img.shields.io/nuget/v/Autodesk.Forge.Core?logo=nuget&label=nuget&color=blue)](https://www.nuget.org/packages/Autodesk.Forge.Core)
 
 ## Overview
 
 ### Requirements
 
-- .NET 8 or later
+- .NET 6 or later
 
 ### Dependencies
 


### PR DESCRIPTION
This PR add support for NET Code 6.0 and NET Code 8.0.

The package gonna have an assembly for both versions.

Until [Microsoft.Extensions.DependencyInjection](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/8.0.0) supports `net6.0` is a good idea to support as well.
