### PR TITLE
⚡ feat: bump minor version to add support for APS environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 4.1.1
 
-- Add support for APS alternative environment variables `APS_CLIENT_ID` and `APS_CLIENT_SECRET`
+* Add support for APS alternative environment variables `APS_CLIENT_ID` and `APS_CLIENT_SECRET`
+* `FORGE_CLIENT_ID` and `FORGE_CLIENT_SECRET` will be deprecated in future!
 
 ### 4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 4.1.1
+
+- Add support for APS alternative environment variables `APS_CLIENT_ID` and `APS_CLIENT_SECRET`
+
 ### 4.0.1
 
 * Add Documentation in the `Autodesk.Forge.Core` project.
@@ -18,18 +22,21 @@
 
 * Migrate to .Net 5
 * Support to return HttpStatusCode in HttpRequestException
-	
 
 ### 1.0.0.0
 
 * 1.0.0-beta4
-   * Support concurrency with `SemaphoreSlim`
+  
+  * Support concurrency with `SemaphoreSlim`
 
 * 1.0.0-beta3
-   * Configurable timeout
+  
+  * Configurable timeout
 
 * 1.0.0-beta2
-   * Fix NuGet package settings
+  
+  * Fix NuGet package settings
 
 * 1.0.0-beta1
-	* Support for `FORGE_CLIENT_ID` and `FORGE_CLIENT_SECRET` environment variables via `ForgeAlternativeConfigurationExtensions`	
+  
+  * Support for `FORGE_CLIENT_ID` and `FORGE_CLIENT_SECRET` environment variables via `ForgeAlternativeConfigurationExtensions`    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 4.1.1
+### 4.1.0
 
 * Add support for APS alternative environment variables `APS_CLIENT_ID` and `APS_CLIENT_SECRET`
 * `FORGE_CLIENT_ID` and `FORGE_CLIENT_SECRET` will be deprecated in future!

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>4.0.1</Version>
+   <Version>4.1.1</Version>
    <TargetFramework>net8.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
  </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <Version>4.1.1</Version>
+   <Version>4.1.0</Version>
    <TargetFramework>net8.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
  </PropertyGroup>

--- a/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
+++ b/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>Shared code for APS client sdks</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Version>4.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
+++ b/src/Autodesk.Forge.Core/Autodesk.Forge.Core.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Description>Shared code for APS client sdks</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>4.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Autodesk.Forge.Core/LegacySampleConfigurationProvider.cs
+++ b/src/Autodesk.Forge.Core/LegacySampleConfigurationProvider.cs
@@ -29,6 +29,8 @@ namespace Autodesk.Forge.Core
         /// </summary>
         /// <param name="configurationBuilder">The configuration builder.</param>
         /// <returns>The configuration builder with Forge alternative environment variables added.</returns>
+        /// 
+        [Obsolete("Use AddAPSAlternativeEnvironmentVariables instead will be removed in future release")]
         public static IConfigurationBuilder AddForgeAlternativeEnvironmentVariables(this IConfigurationBuilder configurationBuilder)
         {
             configurationBuilder.Add(new ForgeAlternativeConfigurationSource());
@@ -123,12 +125,12 @@ namespace Autodesk.Forge.Core
             var id = Environment.GetEnvironmentVariable("APS_CLIENT_ID");
             if (!string.IsNullOrEmpty(id))
             {
-                this.Data.Add("Forge:ClientId", id);
+                this.Data.Add("APS:ClientId", id);
             }
             var secret = Environment.GetEnvironmentVariable("APS_CLIENT_SECRET");
             if (!string.IsNullOrEmpty(secret))
             {
-                this.Data.Add("Forge:ClientSecret", secret);
+                this.Data.Add("APS:ClientSecret", secret);
             }
         }
 

--- a/src/Autodesk.Forge.Core/LegacySampleConfigurationProvider.cs
+++ b/src/Autodesk.Forge.Core/LegacySampleConfigurationProvider.cs
@@ -34,7 +34,22 @@ namespace Autodesk.Forge.Core
             configurationBuilder.Add(new ForgeAlternativeConfigurationSource());
             return configurationBuilder;
         }
+
+        /// <summary>
+        /// Adds APS alternative environment variables to the configuration builder.
+        /// </summary>
+        /// <param name="configurationBuilder"></param>
+        /// <returns></returns>
+
+        public static IConfigurationBuilder AddAPSAlternativeEnvironmentVariables(this IConfigurationBuilder configurationBuilder)
+        {
+            configurationBuilder.Add(new APSAlternativeConfigurationSource());
+            return configurationBuilder;
+        }
+
     }
+
+    
 
     /// <summary>
     /// Represents a configuration source for loading Forge alternative configuration.
@@ -73,6 +88,50 @@ namespace Autodesk.Forge.Core
                 this.Data.Add("Forge:ClientSecret", secret);
             }
         }
+    }
+
+
+
+    /// <summary>
+    /// Represents a configuration source for loading APS alternative configuration.
+    /// </summary>
+
+    public class APSAlternativeConfigurationSource : IConfigurationSource
+    {
+        /// <summary>
+        /// Build the APS Environment Configuration Provider
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            return new APSAlternativeConfigurationProvider();
+        }
+    }
+
+    /// <summary>
+    /// Loads the APS alternative configuration from environment variables.
+    /// </summary>
+
+    public class APSAlternativeConfigurationProvider : ConfigurationProvider
+    {
+        /// <summary>
+        /// Loads the APS alternative configuration from environment variables.
+        /// </summary>
+        public override void Load()
+        {
+            var id = Environment.GetEnvironmentVariable("APS_CLIENT_ID");
+            if (!string.IsNullOrEmpty(id))
+            {
+                this.Data.Add("Forge:ClientId", id);
+            }
+            var secret = Environment.GetEnvironmentVariable("APS_CLIENT_SECRET");
+            if (!string.IsNullOrEmpty(secret))
+            {
+                this.Data.Add("Forge:ClientSecret", secret);
+            }
+        }
+
     }
 }
 

--- a/src/Autodesk.Forge.Core/ServiceCollectionExtensions.cs
+++ b/src/Autodesk.Forge.Core/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ namespace Autodesk.Forge.Core
         {
             services.AddOptions();
             services.Configure<ForgeConfiguration>(configuration.GetSection("Forge"));
+            services.Configure<ForgeConfiguration>(configuration.GetSection("APS"));
             services.AddTransient<ForgeHandler>();
             return services.AddHttpClient<ForgeService>()
                 .AddHttpMessageHandler<ForgeHandler>();
@@ -57,6 +58,7 @@ namespace Autodesk.Forge.Core
         {
             services.AddOptions();
             services.Configure<ForgeConfiguration>(configuration.GetSection("Forge"));
+            services.Configure<ForgeConfiguration>(configuration.GetSection("APS"));
             services.AddTransient<ForgeHandler>();
             return services.AddHttpClient<ForgeService>(user)
                 .AddHttpMessageHandler(() => new ForgeAgentHandler(user))

--- a/tests/Autodesk.Forge.Core.Test/TestAPSConfiguration.cs
+++ b/tests/Autodesk.Forge.Core.Test/TestAPSConfiguration.cs
@@ -1,0 +1,180 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Autodesk.Forge.Core.Test
+{
+    public class TestAPSConfiguration
+    {
+        /// <summary>
+        ///  Tests using APS__ClientId and APS__ClientSecret environment variables dotnet core style
+        /// </summary>
+        [Fact]
+        public void TestAPSConfigFromEnvironmentVariables_DoubleUnderscoreFormat()
+        {
+            Environment.SetEnvironmentVariable("APS__ClientId", "bla");
+            Environment.SetEnvironmentVariable("APS__ClientSecret", "blabla");
+            var configuration = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddForgeService(configuration);
+            var serviceProvider = services.BuildServiceProvider();
+
+            var config = serviceProvider.GetRequiredService<IOptions<ForgeConfiguration>>();
+            Assert.Equal("bla", config.Value.ClientId);
+            Assert.Equal("blabla", config.Value.ClientSecret);
+        }
+
+        /// <summary>
+        /// Tests using APS_CLIENT_ID and APS_CLIENT_SECRET environment variables
+        /// </summary>
+
+        [Fact]
+        public void TestAPSConfigFromEnvironmentVariables_UnderscoreFormat()
+        {
+            Environment.SetEnvironmentVariable("APS_CLIENT_ID", "bla");
+            Environment.SetEnvironmentVariable("APS_CLIENT_SECRET", "blabla");
+            var configuration = new ConfigurationBuilder()
+                .AddAPSAlternativeEnvironmentVariables()
+                .Build();
+            var services = new ServiceCollection();
+            services.AddForgeService(configuration);
+            var serviceProvider = services.BuildServiceProvider();
+            var config = serviceProvider.GetRequiredService<IOptions<ForgeConfiguration>>();
+            Assert.Equal("bla", config.Value.ClientId);
+            Assert.Equal("blabla", config.Value.ClientSecret);
+
+        }
+        /// <summary>
+        /// Tests loading APS configuration values from JSON with ClientId and ClientSecret
+        /// </summary>
+
+        [Fact]
+        public void TestAPSConfigFromJson()
+        {
+            var json = @"
+            {
+                ""APS"" : {
+                    ""ClientId"" : ""bla"",
+                    ""ClientSecret"" : ""blabla""
+                }
+            }";
+            var configuration = new ConfigurationBuilder()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)))
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddForgeService(configuration);
+            var serviceProvider = services.BuildServiceProvider();
+
+            var config = serviceProvider.GetRequiredService<IOptions<ForgeConfiguration>>();
+            Assert.Equal("bla", config.Value.ClientId);
+            Assert.Equal("blabla", config.Value.ClientSecret);
+        }
+
+        /// <summary>
+        /// Tests loading APS configuration values from JSON with additional agent configurations
+        /// </summary>
+
+        [Fact]
+        public void TestAPSConfigFromJsonWithAgents()
+        {
+            var json = @"
+            {
+                ""APS"" : {
+                    ""ClientId"" : ""bla"",
+                    ""ClientSecret"" : ""blabla"",
+                    ""Agents"" : {
+                        ""user1"" : {
+                            ""ClientId"" : ""user1-bla"",
+                            ""ClientSecret"" : ""user1-blabla""
+                        }
+                    }
+                }
+            }";
+            var configuration = new ConfigurationBuilder()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)))
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddForgeService(configuration);
+            var serviceProvider = services.BuildServiceProvider();
+
+            var config = serviceProvider.GetRequiredService<IOptions<ForgeConfiguration>>();
+            Assert.Equal("bla", config.Value.ClientId);
+            Assert.Equal("blabla", config.Value.ClientSecret);
+            Assert.Equal("user1-bla", config.Value.Agents["user1"].ClientId);
+            Assert.Equal("user1-blabla", config.Value.Agents["user1"].ClientSecret);
+        }
+
+        /// <summary>  
+        /// Tests APS configuration for user agent "user1" and checks proper handling of authentication and request headers.
+        /// </summary>
+        [Fact]
+        public async Task TestAPSUserAgent()
+        {
+            var json = @"
+            {
+                ""APS"" : {
+                    ""ClientId"" : ""bla"",
+                    ""ClientSecret"" : ""blabla"",
+                    ""Agents"" : {
+                        ""user1"" : {
+                            ""ClientId"" : ""user1-bla"",
+                            ""ClientSecret"" : ""user1-blabla""
+                        }
+                    }
+                }
+            }";
+            var configuration = new ConfigurationBuilder()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)))
+                .Build();
+
+            var sink = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var services = new ServiceCollection();
+            services.AddForgeService("user1", configuration).ConfigurePrimaryHttpMessageHandler(() => sink.Object);
+            var serviceProvider = services.BuildServiceProvider();
+            var config = serviceProvider.GetRequiredService<IOptions<ForgeConfiguration>>().Value;
+            var req = new HttpRequestMessage();
+            req.RequestUri = new Uri("http://example.com");
+            req.Options.Set(ForgeConfiguration.ScopeKey, "somescope");
+
+            string user = null;
+            sink.Protected().As<HttpMessageInvoker>().Setup(o => o.SendAsync(It.Is<HttpRequestMessage>(r => r.RequestUri == config.AuthenticationAddress), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(new Dictionary<string, string> { { "token_type", "Bearer" }, { "access_token", "blablabla" }, { "expires_in", "3" } })),
+                    StatusCode = System.Net.HttpStatusCode.OK
+                });
+            sink.Protected().As<HttpMessageInvoker>().Setup(o => o.SendAsync(It.Is<HttpRequestMessage>(r => r.RequestUri == req.RequestUri), It.IsAny<CancellationToken>()))
+                .Callback<HttpRequestMessage, CancellationToken>((r, ct) =>
+                {
+                    r.Options.TryGetValue(ForgeConfiguration.AgentKey, out user);
+                })
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = System.Net.HttpStatusCode.OK
+                });
+
+
+            var clientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+            var client = clientFactory.CreateClient("user1");
+            var resp = await client.SendAsync(req, CancellationToken.None);
+
+            sink.Protected().As<HttpMessageInvoker>().Verify(o => o.SendAsync(It.Is<HttpRequestMessage>(r => r.RequestUri == config.AuthenticationAddress), It.IsAny<CancellationToken>()), Times.Once());
+            sink.Protected().As<HttpMessageInvoker>().Verify(o => o.SendAsync(It.Is<HttpRequestMessage>(r => r.RequestUri == req.RequestUri), It.IsAny<CancellationToken>()), Times.Once());
+            Assert.Equal("user1", user);
+        }
+    }
+}

--- a/tests/Autodesk.Forge.Core.Test/TestForgeConfiguration.cs
+++ b/tests/Autodesk.Forge.Core.Test/TestForgeConfiguration.cs
@@ -52,6 +52,23 @@ namespace Autodesk.Forge.Core.Test
         }
 
         [Fact]
+        public void TestValuesFromAPSEnvironment()
+        {
+            Environment.SetEnvironmentVariable("APS_CLIENT_ID", "bla");
+            Environment.SetEnvironmentVariable("APS_CLIENT_SECRET", "blabla");
+            var configuration = new ConfigurationBuilder()
+                .AddAPSAlternativeEnvironmentVariables()
+                .Build();
+            var services = new ServiceCollection();
+            services.AddForgeService(configuration);
+            var serviceProvider = services.BuildServiceProvider();
+            var config = serviceProvider.GetRequiredService<IOptions<ForgeConfiguration>>();
+            Assert.Equal("bla", config.Value.ClientId);
+            Assert.Equal("blabla",config.Value.ClientSecret);
+
+        }
+
+        [Fact]
         public void TestValuesFromJson()
         {
             var json = @"


### PR DESCRIPTION
⚡ **feat**: bump minor version to add support for APS environment variables

- Introduced `AddAPSAlternativeEnvironmentVariables` extension method to add APS environment variables to the configuration builder.
- Created `APSAlternativeConfigurationSource` class to represent the configuration source for APS.
- Implemented `APSAlternativeConfigurationProvider` class to load APS configuration from environment variables.

Add unit tests for APS alternative environment variables

- Added `TestValuesFromAPSEnvironment` to verify loading of APS environment variables.
- Ensured tests cover various configuration sources including environment variables, JSON, and legacy environment variables.

